### PR TITLE
Сделал HitBox более универсальным

### DIFF
--- a/Paint-it-Black/hit_box.gd
+++ b/Paint-it-Black/hit_box.gd
@@ -1,5 +1,5 @@
 extends Area2D
-class_name BasicHitBox
+class_name HitBox
 ## Основной hit-box в игре.
 ##
 ## hit-box, обнаруживающий пересечение с [HurtBoxInterface] и его наследниками,
@@ -10,11 +10,18 @@ class_name BasicHitBox
 
 ## Испускается, когда была нанесена атака объекту [HurtBoxInterface], передаёт
 ## ссылку на этот объект в параметре [param hurt_box].
-signal hit(hurt_box: HurtBoxInterface)
+signal hit(area: Area2D)
 
 ## Параметры атаки, которые будут переданы в [HurtBoxInterface] для последующей
 ## обработки.
 @export var attack_data: AttackData
+## Массив названий групп, которые данный [HitBox] может атаковать.
+@export var hittable_groups: Array[StringName]
+
+
+## Проверяет наличие данных об атаке
+func _ready():
+	assert(attack_data != null, "Отсутствует AttackData")
 
 
 ## Связывает сигнал [signal area_entered] из родительского класса [Area2D] с
@@ -27,5 +34,7 @@ func _init() -> void:
 ## [HurtBoxInterface], то передаёт ему данные об атаке [member attack_data].
 func _on_area_entered(area: Area2D) -> void:
 	if area is HurtBoxInterface:
-		hit.emit(area)
-		area._hurt(attack_data)
+		# Эту группу можно атаковать?
+		if area.get_groups().any(func(group): return group in hittable_groups):
+			hit.emit(area)
+			area._hurt(attack_data)

--- a/Paint-it-Black/hit_box.gd
+++ b/Paint-it-Black/hit_box.gd
@@ -10,7 +10,7 @@ class_name HitBox
 
 ## Испускается, когда была нанесена атака объекту [HurtBoxInterface], передаёт
 ## ссылку на этот объект в параметре [param hurt_box].
-signal hit(area: Area2D)
+signal hit(area: HurtBoxInterface)
 
 ## Параметры атаки, которые будут переданы в [HurtBoxInterface] для последующей
 ## обработки.


### PR DESCRIPTION
Теперь для разных персонажей можно использовать один и тот же HitBox и указывать в нём группы, которые он может атаковать.