### PR TITLE
Частичный фикс бага #65

### DIFF
--- a/Paint-it-Black/dummy.tscn
+++ b/Paint-it-Black/dummy.tscn
@@ -19,6 +19,8 @@ height = 60.0
 size = Vector2(36, 60)
 
 [node name="Dummy" type="CharacterBody2D"]
+collision_layer = 2
+collision_mask = 4
 script = ExtResource("1_f8ldm")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
@@ -26,6 +28,8 @@ texture = ExtResource("1_57h2s")
 flip_h = true
 
 [node name="PlayerHurtBox" type="Area2D" parent="." groups=["enemy"]]
+collision_layer = 2
+collision_mask = 0
 script = ExtResource("2_tc3wo")
 
 [node name="HP" type="Node" parent="PlayerHurtBox"]

--- a/Paint-it-Black/hit_box.gd
+++ b/Paint-it-Black/hit_box.gd
@@ -11,6 +11,8 @@ class_name HitBox
 ## Испускается, когда была нанесена атака объекту [HurtBoxInterface], передаёт
 ## ссылку на этот объект в параметре [param hurt_box].
 signal hit(hurt_box: HurtBoxInterface)
+## Испускается, когда было обнаружено пересечение с твёрдой поверхностью.
+signal hit_solid_surface(solid_surface: Node2D)
 
 ## Параметры атаки, которые будут переданы в [HurtBoxInterface] для последующей
 ## обработки.
@@ -27,10 +29,11 @@ func _ready():
 	$HitBoxShape.visible = false
 
 
-## Связывает сигнал [signal area_entered] из родительского класса [Area2D] с
-## приватным методом [method _on_area_entered].
+## Связывает нужные сигналы с соответствующими функциями, дабы расширить
+## функционал базового [Aread2D].
 func _init() -> void:
 	connect("area_entered", _on_area_entered)
+	connect("body_entered", _on_body_entered)
 
 
 ## Обрабатывает пересечение с [Area2D]: если [Area2D] является
@@ -43,3 +46,10 @@ func _on_area_entered(area: Area2D) -> void:
 			attack.damage = attack_data.damage
 			hit.emit(area)
 			area._hurt(attack)
+
+
+## Обнаруживает пересечение с твёрдой поверхностью испускает сигнал
+## [signal hit_static_body].
+func _on_body_entered(body: Node2D) -> void:
+	if body is TileMap:
+		hit_solid_surface.emit(body)

--- a/Paint-it-Black/player/player.tscn
+++ b/Paint-it-Black/player/player.tscn
@@ -118,6 +118,7 @@ movement_data = ExtResource("3_pti2n")
 character_body = NodePath("..")
 
 [node name="HurtBox" type="Area2D" parent="."]
+collision_mask = 0
 script = ExtResource("3_ovg4b")
 
 [node name="HP" type="Node" parent="HurtBox"]
@@ -150,6 +151,7 @@ movement_component = NodePath("../MovementComponent")
 
 [node name="HitBox" type="Area2D" parent="PlayerAttack"]
 position = Vector2(0, -9)
+collision_mask = 6
 script = ExtResource("10_urtlw")
 attack_data = ExtResource("10_j7iwd")
 hittable_groups = Array[StringName]([&"enemy"])

--- a/Paint-it-Black/player/player.tscn
+++ b/Paint-it-Black/player/player.tscn
@@ -175,3 +175,5 @@ root_node = NodePath("../HitBox")
 libraries = {
 "": SubResource("AnimationLibrary_4ka6q")
 }
+
+[connection signal="hit_solid_surface" from="PlayerAttack/HitBox" to="PlayerAttack" method="_on_hit_box_hit_solid_surface"]

--- a/Paint-it-Black/player/scripts/player_attack.gd
+++ b/Paint-it-Black/player/scripts/player_attack.gd
@@ -81,6 +81,22 @@ func attack(direction: Vector2) -> void:
 		_is_attack_ready = true
 
 
+## Отменяет атаку при пересечении с твёрдой поверхностью.
+func _on_hit_box_hit_solid_surface(solid_surface: Node2D) -> void:
+	if !Engine.is_editor_hint():
+		call_deferred("_advance_animation")
+
+
+## Приватный метод, преждевремменно завершает анимацию. При этом анимация
+## "отзеркаливается" к завершению, а не просто прерывается.
+func _advance_animation():
+	if _animation_player.is_playing():
+		var advance_seconds: float
+		advance_seconds = _animation_player.get_animation("hit_box_attack").length
+		advance_seconds -= 2 * _animation_player.current_animation_position
+		_animation_player.advance(advance_seconds)
+
+
 ## Проверка наличия [HitBox] в качестве дочернего узла.
 func _check_hit_box(warnings: PackedStringArray = []) -> void:
 	var hit_box_components: Array =\
@@ -134,7 +150,7 @@ func _check_player_movement(warnings: PackedStringArray = []) -> void:
 			assert(false, "Отсутствует ссылка на PlayerMovement")
 
 
-## Проверка наличия данных об атаке
+## Проверка наличия данных об атаке.
 func _check_attack_data(warnings: PackedStringArray = []) -> void:
 	if attack_data ==  null:
 		if Engine.is_editor_hint():


### PR DESCRIPTION
Теперь, если хитбокс попадает в область какого-то твёрдого объекта (пол, стены и т.п.), то анимация расширения хитбокса возвращается в обратную сторону, не позволяя пройти хитбоксу дальше. Но из-за скорости анимации иногда даже в пределах одного кадра хитбокс успевает пройти через 1 тайл твёрдого объекта, из-за чего подобное решение работает только частично.