### PR TITLE
Обновил поведение атаки игрока

### DIFF
--- a/Paint-it-Black/basic_character_movement.gd
+++ b/Paint-it-Black/basic_character_movement.gd
@@ -42,6 +42,7 @@ func _physics_process(delta) -> void:
 
 	_apply_gravity(delta)
 	character_body.move_and_slide()
+	_crop_speed()
 
 
 func turn_on_platform_collision() -> void:
@@ -170,3 +171,16 @@ func add_velocity(velocity: Vector2) -> void:
 		push_error("Невозможно осуществить add_velocity() без character_body")
 		return
 	character_body.velocity += velocity
+
+
+func set_velocity(velocity: Vector2) -> void:
+	if not _has_character_body:
+		push_error("Невозможно осуществить set_velocity() без character_body")
+		return
+	character_body.velocity = velocity
+	_crop_speed()
+
+
+func _crop_speed() -> void:
+	character_body.velocity.x = clampf(character_body.velocity.x, -movement_data.max_horizontal_speed, movement_data.max_horizontal_speed)
+	character_body.velocity.y = clampf(character_body.velocity.y, -movement_data.max_up_speed, movement_data.max_fall_speed)

--- a/Paint-it-Black/basic_movement_data.gd
+++ b/Paint-it-Black/basic_movement_data.gd
@@ -17,8 +17,11 @@ extends CustomResource
 ## Действующая гравитация.
 @export_range(0, 100, 0.1, "or_greater")
 var gravity: float = ProjectSettings.get_setting("physics/2d/default_gravity")
+@export_group("Max Speed")
 ## Максимальная скорость падения.
 @export_range(0, 100, 0.1, "or_greater") var max_fall_speed: float
+@export_range(0, 100, 0.1, "or_greater") var max_up_speed: float
+@export_range(0, 100, 0.1, "or_greater") var max_horizontal_speed: float
 
 
 func _init() -> void:

--- a/Paint-it-Black/player/player.tscn
+++ b/Paint-it-Black/player/player.tscn
@@ -1,11 +1,11 @@
-[gd_scene load_steps=36 format=3 uid="uid://b5qdqaaw2hat6"]
+[gd_scene load_steps=37 format=3 uid="uid://b5qdqaaw2hat6"]
 
 [ext_resource type="Script" path="res://player/scripts/player_manager.gd" id="1_3hyi7"]
 [ext_resource type="Script" path="res://player/scripts/player_controller.gd" id="1_kt7rl"]
 [ext_resource type="Script" path="res://player/scripts/player_movement.gd" id="2_02ofg"]
 [ext_resource type="SpriteFrames" uid="uid://dlj10bsjifa2w" path="res://player/resources/player_animations.tres" id="2_mc37b"]
 [ext_resource type="Script" path="res://player/scripts/player_animation_controller.gd" id="3_eywrf"]
-[ext_resource type="Resource" uid="uid://cjeut3m67l1iw" path="res://player/resources/player_movement_data.tres" id="3_pti2n"]
+[ext_resource type="Script" path="res://player/resources/player_movement_data.gd" id="6_d5dvb"]
 [ext_resource type="Script" path="res://player/scripts/player_attack.gd" id="7_bi60k"]
 [ext_resource type="Script" path="res://addons/godot_state_charts/state_chart.gd" id="9_2qwus"]
 [ext_resource type="Script" path="res://basic_hurt_box.gd" id="9_obpaw"]
@@ -30,6 +30,19 @@
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_20xhv"]
 size = Vector2(20, 64)
+
+[sub_resource type="Resource" id="Resource_y1hhy"]
+script = ExtResource("6_d5dvb")
+jump_speed = 200.0
+jump_angle = 45.0
+sliding_acceleration = 100.0
+max_sliding_speed = 50.0
+movement_acceleration = 600.0
+max_movement_speed = 200.0
+gravity = 300.0
+max_fall_speed = 400.0
+max_up_speed = 400.0
+max_horizontal_speed = 300.0
 
 [sub_resource type="Resource" id="Resource_86q88"]
 script = ExtResource("9_t1hns")
@@ -219,7 +232,7 @@ animated_sprite = NodePath("../AnimatedSprite2D")
 
 [node name="PlayerMovement" type="Node" parent="." node_paths=PackedStringArray("character_body")]
 script = ExtResource("2_02ofg")
-movement_data = ExtResource("3_pti2n")
+movement_data = SubResource("Resource_y1hhy")
 character_body = NodePath("..")
 
 [node name="PlayerAttack" type="Node2D" parent="." node_paths=PackedStringArray("movement_component")]

--- a/Paint-it-Black/player/resources/player_movement_data.tres
+++ b/Paint-it-Black/player/resources/player_movement_data.tres
@@ -12,3 +12,5 @@ movement_acceleration = 600.0
 max_movement_speed = 200.0
 gravity = 300.0
 max_fall_speed = 400.0
+max_up_speed = 600.0
+max_horizontal_speed = 500.0

--- a/Paint-it-Black/player/scripts/player_attack.gd
+++ b/Paint-it-Black/player/scripts/player_attack.gd
@@ -126,7 +126,7 @@ func _attack(direction: Vector2, impulse: float) -> void:
 
 	# Импульс в заданном направлении
 	direction = direction.normalized()
-	movement_component.add_velocity(direction * impulse)
+	_calc_velocity(direction * impulse)
 
 	# Задать новое направление атаки в ресурс
 	_hit_box.attack_data.direction = direction
@@ -139,6 +139,18 @@ func _attack(direction: Vector2, impulse: float) -> void:
 	await get_tree().create_timer(attack_data.cooldown + attack_data.duration).timeout
 	_is_attack_ready = true
 	attack_ready.emit()
+
+
+func _calc_velocity(velocity: Vector2):
+	if sign(movement_component.character_body.velocity.x) == sign(velocity.x):
+		movement_component.character_body.velocity.x += velocity.x
+	else:
+		movement_component.character_body.velocity.x = velocity.x
+
+	if sign(movement_component.character_body.velocity.y) == sign(velocity.y):
+		movement_component.character_body.velocity.y += velocity.y
+	else:
+		movement_component.character_body.velocity.y = velocity.y
 
 
 ## Отменяет атаку при пересечении с твёрдой поверхностью.


### PR DESCRIPTION
В итоге не стал полностью делать атаку как в Katana:ZERO: если полностью заменять скорость игрока во время атаки, то управление начинает ощущаться слишком топорно.

В итоге сделал следующее:
- Ограничил максимально возможную скорость игрока по всем 4-м сторонам
- Если импульс атаки по какой-то оси направлен в противоположную сторону от текущего вектора скорости, то составляющая скорости по этой оси заменяется импульсом атаки. В противном случае идёт суммирование скоростей.